### PR TITLE
Feature/assembly hub

### DIFF
--- a/bin/biotype_table_parser.r
+++ b/bin/biotype_table_parser.r
@@ -10,7 +10,7 @@ names(table1)= c("Ala_tRNA", "Arg_tRNA", "Asn_tRNA", "Asp_tRNA", "Cys_tRNA", "Gl
                      "misc_RNA", "polymorphic_pseudogene", "processed_pseudogene", "protein_coding", "pseudogene", "rRNA", "rRNA_pseudogene", "ribozyme", "sRNA", "scRNA",
                      "scaRNA", "snRNA", "snoRNA", "spike_in", "transcribed_processed_pseudogene", "transcribed_unitary_pseudogene", "transcribed_unprocessed_pseudogene",
                      "translated_processed_pseudogene", "translated_unprocessed_pseudogene", "unitary_pseudogene", "unprocessed_pseudogene", "vault_RNA")
-table2= read.csv("multiqc_data/mqc_featurecounts_biotype_plot.txt", header = T, row.names=1, sep= "\t")
+table2= read.csv("multiqc_data/multiqc_featurecounts_biotype_plot.txt", header = T, row.names=1, sep= "\t")
 
 table_final= bind_rows(table1,table2)
 table_final[is.na(table_final)] <- 0

--- a/bin/biotype_table_parser.r
+++ b/bin/biotype_table_parser.r
@@ -10,7 +10,7 @@ names(table1)= c("Ala_tRNA", "Arg_tRNA", "Asn_tRNA", "Asp_tRNA", "Cys_tRNA", "Gl
                      "misc_RNA", "polymorphic_pseudogene", "processed_pseudogene", "protein_coding", "pseudogene", "rRNA", "rRNA_pseudogene", "ribozyme", "sRNA", "scRNA",
                      "scaRNA", "snRNA", "snoRNA", "spike_in", "transcribed_processed_pseudogene", "transcribed_unitary_pseudogene", "transcribed_unprocessed_pseudogene",
                      "translated_processed_pseudogene", "translated_unprocessed_pseudogene", "unitary_pseudogene", "unprocessed_pseudogene", "vault_RNA")
-table2= read.csv("multiqc_data/mqc_featurecounts_biotype_plot_1.txt", header = T, row.names=1, sep= "\t")
+table2= read.csv("multiqc_data/mqc_featurecounts_biotype_plot.txt", header = T, row.names=1, sep= "\t")
 
 table_final= bind_rows(table1,table2)
 table_final[is.na(table_final)] <- 0

--- a/bin/make_trackDB.sh
+++ b/bin/make_trackDB.sh
@@ -15,14 +15,24 @@ for file in *.bam
 done
 
 #Create hub.txt
-echo -e "hub $project\nshortLabel $project project\nlongLabel samples from the $project project\ngenomesFile genomes.txt\nemail lluc.cabus@flomics.com" > hub.txt
-echo -e "track $prefix\nbigDataUrl ${http_folder}dataFiles/$bam\nshortLabel $prefix\nlongLabel $prefix sample of the project $project\ntype bam\nvisibility full\ndoWiggle on\nmaxHeightPixels 100:32:10\n" > ${prefix}_trackDb.txt
-echo "http://genome-euro.ucsc.edu/cgi-bin/hgTracks?hubUrl=${http_folder}hub.txt" > UCSC.txt
-echo -e "genome hg38\ntrackDb hg38/trackDb.txt" > genomes.txt
+mkdir -p trackhub
+echo -e "hub $project\nshortLabel $project project\nlongLabel samples from the $project project\ngenomesFile genomes.txt\nemail lluc.cabus@flomics.com" > trackhub/hub.txt
+echo -e "track $prefix\nbigDataUrl ${http_folder}dataFiles/$bam\nshortLabel $prefix\nlongLabel $prefix sample of the project $project\ntype bam\nvisibility full\ndoWiggle on\nmaxHeightPixels 100:32:10\n" > trackhub/${prefix}_trackDb.txt
+echo "http://genome-euro.ucsc.edu/cgi-bin/hgTracks?hubUrl=${http_folder}hub.txt" > trackhub/UCSC.txt
+echo -e "genome hg38\ntrackDb hg38/trackDb.txt" > trackhub/genomes.txt
+
+#Create assembly hub
+mkdir -p assembly_hub
+echo -e "hub $project\nshortLabel $project project\nlongLabel samples from the $project project\ngenomesFile genomes.txt\nemail marc.weber@flomics.com" > assembly_hub/hub.txt
+echo -e "track $prefix\nbigDataUrl ${http_folder}dataFiles/$bam\nshortLabel $prefix\nlongLabel $prefix sample of the project $project\ntype bam\nvisibility full\ndoWiggle on\nmaxHeightPixels 100:32:10\n" > assembly_hub/${prefix}_trackDb.txt
+echo "http://genome-euro.ucsc.edu/cgi-bin/hgTracks?hubUrl=${http_folder}assembly_hub.hub.txt" >> assembly_hub/UCSC.txt
+echo -e "genome hg38_ERCC_spikeins\ntrackDb hg38_ERCC_spikeins/trackDb.txt\ntwoBitPath hg38_ERCC_spikeins/hg38_ERCC_spikeins.2bit\norganism H. sapiens\ndefaultPos ERCC-00130:1-1051" > assembly_hub/genomes.txt
 
 #Upload files to s3
 if [[ $profile != *"test"* ]]; then
     aws s3 cp . ${s3_bucket_name}dataFiles/ --recursive --exclude "*" --include "*.bam*" --acl public-read
-    aws s3 cp hub.txt $s3_bucket_name --acl public-read
-    aws s3 cp genomes.txt $s3_bucket_name --acl public-read
+    aws s3 cp trackhub/hub.txt ${s3_bucket_name}trackhub/ --acl public-read
+    aws s3 cp trackhub/genomes.txt ${s3_bucket_name}trackhub/ --acl public-read
+    aws s3 cp assembly_hub/hub.txt ${s3_bucket_name}assembly_hub/ --acl public-read
+    aws s3 cp assembly_hub/genomes.txt ${s3_bucket_name}assembly_hub/ --acl public-read
 fi

--- a/bin/make_trackDB.sh
+++ b/bin/make_trackDB.sh
@@ -23,8 +23,17 @@ echo -e "genome hg38\ntrackDb hg38/trackDb.txt" > trackhub/genomes.txt
 
 #Create assembly hub
 mkdir -p assembly_hub
-echo -e "hub $project\nshortLabel $project project\nlongLabel samples from the $project project\ngenomesFile genomes.txt\nemail marc.weber@flomics.com" > assembly_hub/hub.txt
-echo -e "track $prefix\nbigDataUrl ${http_folder}dataFiles/$bam\nshortLabel $prefix\nlongLabel $prefix sample of the project $project\ntype bam\nvisibility full\ndoWiggle on\nmaxHeightPixels 100:32:10\n" > assembly_hub/${prefix}_trackDb.txt
+echo -e "hub $project\nshortLabel $project project\nlongLabel $project\ngenomesFile genomes.txt\nemail marc.weber@flomics.com" > assembly_hub/hub.txt
+# echo -e "track $prefix\nbigDataUrl ${http_folder}dataFiles/$bam\nshortLabel $prefix\nlongLabel $prefix sample of the project $project\ntype bam\nvisibility full\ndoWiggle on\nmaxHeightPixels 100:32:10\n" > assembly_hub/${prefix}_trackDb.txt
+# Writing the $prefix_trackDB.txt file using multiline string entry (bash heredoc)
+cat << EOF > assembly_hub/${prefix}_trackDb.txt
+track $prefix
+parent all_samples on
+bigDataUrl ${http_folder}dataFiles/$bam
+shortLabel $prefix
+longLabel $prefix sample of the project $project
+EOF
+
 echo "http://genome-euro.ucsc.edu/cgi-bin/hgTracks?hubUrl=${http_folder}assembly_hub.hub.txt" >> assembly_hub/UCSC.txt
 echo -e "genome hg38_ERCC_spikeins\ntrackDb hg38_ERCC_spikeins/trackDb.txt\ntwoBitPath https://flomics-public.s3.eu-west-1.amazonaws.com/references/Genomes/Homo_sapiens/hg38_ERCC_spikeins/hg38_ERCC_spikeins.2bit\norganism H. sapiens\ndefaultPos ERCC-00130:1-1051" > assembly_hub/genomes.txt
 

--- a/bin/make_trackDB.sh
+++ b/bin/make_trackDB.sh
@@ -26,7 +26,7 @@ mkdir -p assembly_hub
 echo -e "hub $project\nshortLabel $project project\nlongLabel samples from the $project project\ngenomesFile genomes.txt\nemail marc.weber@flomics.com" > assembly_hub/hub.txt
 echo -e "track $prefix\nbigDataUrl ${http_folder}dataFiles/$bam\nshortLabel $prefix\nlongLabel $prefix sample of the project $project\ntype bam\nvisibility full\ndoWiggle on\nmaxHeightPixels 100:32:10\n" > assembly_hub/${prefix}_trackDb.txt
 echo "http://genome-euro.ucsc.edu/cgi-bin/hgTracks?hubUrl=${http_folder}assembly_hub.hub.txt" >> assembly_hub/UCSC.txt
-echo -e "genome hg38_ERCC_spikeins\ntrackDb hg38_ERCC_spikeins/trackDb.txt\ntwoBitPath hg38_ERCC_spikeins/hg38_ERCC_spikeins.2bit\norganism H. sapiens\ndefaultPos ERCC-00130:1-1051" > assembly_hub/genomes.txt
+echo -e "genome hg38_ERCC_spikeins\ntrackDb hg38_ERCC_spikeins/trackDb.txt\ntwoBitPath https://flomics-public.s3.eu-west-1.amazonaws.com/references/Genomes/Homo_sapiens/hg38_ERCC_spikeins/hg38_ERCC_spikeins.2bit\norganism H. sapiens\ndefaultPos ERCC-00130:1-1051" > assembly_hub/genomes.txt
 
 #Upload files to s3
 if [[ $profile != *"test"* ]]; then

--- a/bin/make_trackDB.sh
+++ b/bin/make_trackDB.sh
@@ -31,7 +31,8 @@ track $prefix
 parent all_samples on
 bigDataUrl ${http_folder}dataFiles/$bam
 shortLabel $prefix
-longLabel $prefix sample of the project $project
+longLabel $prefix - project $project
+
 EOF
 
 echo "http://genome-euro.ucsc.edu/cgi-bin/hgTracks?hubUrl=${http_folder}assembly_hub.hub.txt" >> assembly_hub/UCSC.txt

--- a/bin/merge_trackDB.sh
+++ b/bin/merge_trackDB.sh
@@ -5,10 +5,19 @@ profile=$3
 s3_bucket_name="s3://flomics-public/RNAseq_pipeline/$project/$uuid/"
 
 #Aggregate track_Db.txt files and uploads them to s3
-for file in *trackDb.txt
-do cat $file >> trackDb.txt
+for file in trackhub/*_trackDB.txt
+do cat $file >> trackhub/trackDb.txt
 done
 
 if [[ $profile != *"test"* ]]; then
-    aws s3 cp trackDb.txt ${s3_bucket_name}hg38/ --acl public-read
+    aws s3 cp trackhub/trackDb.txt ${s3_bucket_name}trackhub/hg38/ --acl public-read
+fi
+
+#Aggregate assembly hub track_Db.txt files and uploads them to s3
+for file in assembly_hub/*_trackDb.txt
+do cat $file >> assembly_hub/trackDb.txt
+done
+
+if [[ $profile != *"test"* ]]; then
+    aws s3 cp assembly_hub/trackDb.txt ${s3_bucket_name}assembly_hub/hg38_ERCC_spikeins/ --acl public-read
 fi

--- a/bin/merge_trackDB.sh
+++ b/bin/merge_trackDB.sh
@@ -6,7 +6,8 @@ s3_bucket_name="s3://flomics-public/RNAseq_pipeline/$project/$uuid/"
 
 #Aggregate track_Db.txt files and uploads them to s3
 for file in trackhub/*_trackDB.txt
-do cat $file >> trackhub/trackDb.txt
+do
+    cat $file >> trackhub/trackDb.txt
 done
 
 if [[ $profile != *"test"* ]]; then
@@ -32,7 +33,8 @@ doWiggle on
 
 
 EOF
-for file in assembly_hub/*_trackDb.txt do
+for file in assembly_hub/*_trackDb.txt
+do
     cat $file >> assembly_hub/trackDb.txt
 done
 

--- a/bin/merge_trackDB.sh
+++ b/bin/merge_trackDB.sh
@@ -5,7 +5,7 @@ profile=$3
 s3_bucket_name="s3://flomics-public/RNAseq_pipeline/$project/$uuid/"
 
 #Aggregate track_Db.txt files and uploads them to s3
-for file in trackhub/*_trackDB.txt
+for file in trackhub/*_trackDb.txt
 do
     cat $file >> trackhub/trackDb.txt
 done

--- a/bin/merge_trackDB.sh
+++ b/bin/merge_trackDB.sh
@@ -13,11 +13,32 @@ if [[ $profile != *"test"* ]]; then
     aws s3 cp trackhub/trackDb.txt ${s3_bucket_name}trackhub/hg38/ --acl public-read
 fi
 
-#Aggregate assembly hub track_Db.txt files and uploads them to s3
-for file in assembly_hub/*_trackDb.txt
-do cat $file >> assembly_hub/trackDb.txt
+# Aggregate assembly hub track_Db.txt files and uploads them to s3
+# We use a parent composite track (group of tracks) to simplify
+# the configuration of all the tracks.
+# See https://genome.ucsc.edu/goldenpath/help/hubQuickStartGroups.html#composite
+cat << EOF > assembly_hub/trackDb.txt
+track all_samples
+compositeTrack on
+shortLabel ${project}_all_samples
+longLabel ${project}_all_samples
+type bam
+allButtonPair on
+visibility full
+autoscale on
+maxHeightPixels 500:32:10
+visibility full
+doWiggle on
+
+
+EOF
+for file in assembly_hub/*_trackDb.txt do
+    cat $file >> assembly_hub/trackDb.txt
 done
 
 if [[ $profile != *"test"* ]]; then
     aws s3 cp assembly_hub/trackDb.txt ${s3_bucket_name}assembly_hub/hg38_ERCC_spikeins/ --acl public-read
+    # We also copy the multi-region bed file from the genome reference folder to the
+    # assembly hub folder on the public bucket
+    aws s3 cp s3://flomics-no-backup/references/Genomes/Homo_sapiens/hg38_ERCC_spikeins/multiregion_all_spikeins.bed ${s3_bucket_name}assembly_hub/hg38_ERCC_spikeins/ --acl public-read
 fi

--- a/modules/local/Flomics_QC_agreggator.nf
+++ b/modules/local/Flomics_QC_agreggator.nf
@@ -7,10 +7,10 @@ process FLOMICS_QC_AGGREGATOR{
     input:
     path samplesheet
     path multiqc_data
-    path "trackhub/*_trackhub_links.tsv"
-    path "trackhub/*_trackDb.txt"
-    path "assembly_hub/*_trackhub_links.tsv"
-    path "assembly_hub/*_trackDb.txt"
+    path "trackhub/*"
+    path "trackhub/*"
+    path "assembly_hub/*"
+    path "assembly_hub/*"
     path splicedReads_QC
     path spliceJunctions_QC
     path insert_size

--- a/modules/local/Flomics_QC_agreggator.nf
+++ b/modules/local/Flomics_QC_agreggator.nf
@@ -7,8 +7,10 @@ process FLOMICS_QC_AGGREGATOR{
     input:
     path samplesheet
     path multiqc_data
-    path trackhub_links
-    path trackDbs
+    path "trackhub/*_trackhub_links.tsv"
+    path "trackhub/*_trackDb.txt"
+    path "assembly_hub/*_trackhub_links.tsv"
+    path "assembly_hub/*_trackDb.txt"
     path splicedReads_QC
     path spliceJunctions_QC
     path insert_size
@@ -35,10 +37,19 @@ process FLOMICS_QC_AGGREGATOR{
 
     echo -e "Sample\ttrackhub_link" > trackhub_links.tsv
     while IFS= read -r sample; do
-        if test -f "${sample}_trackhub_links.tsv"; then
-            cat ${sample}_trackhub_links.tsv | sed "s/^/$sample\t/" >> trackhub_links.tsv
+        if test -f "trackhub/${sample}_trackhub_links.tsv"; then
+            cat trackhub/${sample}_trackhub_links.tsv | sed "s/^/$sample\t/" >> trackhub/trackhub_links.tsv
         else
-            echo -e "$sample\tNA" >> trackhub_links.tsv
+            echo -e "$sample\tNA" >> trackhub/trackhub_links.tsv
+        fi
+    done < samples.tsv
+
+    echo -e "Sample\ttrackhub_link" > assembly_hub/trackhub_links.tsv
+    while IFS= read -r sample; do
+        if test -f "assembly_hub/${sample}_trackhub_links.tsv"; then
+            cat assembly_hub/${sample}_trackhub_links.tsv | sed "s/^/$sample\t/" >> assembly_hub/trackhub_links.tsv
+        else
+            echo -e "$sample\tNA" >> assembly_hub/trackhub_links.tsv
         fi
     done < samples.tsv
 

--- a/modules/local/Flomics_trackhubs.nf
+++ b/modules/local/Flomics_trackhubs.nf
@@ -10,9 +10,10 @@ process FLOMICS_TRACKHUBS{
     tuple val(meta), path(bai)
 
     output:
-    path "*_trackhub_links.tsv", emit: trackhubs_path
-    path "*_trackDb.txt", emit: trackDb_files
-
+    path "trackhub/*_trackhub_links.tsv",     emit: trackhub_links
+    path "trackhub/*_trackDb.txt",            emit: trackhub_trackDb_files
+    path "assembly_hub/*_trackhub_links.tsv", emit: assembly_hub_links
+    path "assembly_hub/*_trackDb.txt",        emit: assembly_hub_trackDb_files
 
     script:
     prefix  = task.ext.prefix ?: "${meta.id}"
@@ -22,6 +23,7 @@ process FLOMICS_TRACKHUBS{
 
     """
     make_trackDB.sh $bam $prefix $project $uuid $profile
-    cat UCSC.txt >> ${prefix}_trackhub_links.tsv
+    cat trackhub/UCSC.txt >> trackhub/${prefix}_trackhub_links.tsv
+    cat assembly_hub/UCSC.txt >> assembly_hub/${prefix}_trackhub_links.tsv
     """
 }

--- a/subworkflows/local/Flomics_QC.nf
+++ b/subworkflows/local/Flomics_QC.nf
@@ -36,11 +36,15 @@ workflow FLOMICS_QC{
     ///
     /// Makes the trackhubs and copies the bam files to the public bucket of s3
     ///
-    ch_Flomics_trackhubs           = Channel.empty()
-    ch_Flomics_trackDbs            = Channel.empty()
+    ch_Flomics_trackhubs              = Channel.empty()
+    ch_Flomics_trackDbs               = Channel.empty()
+    ch_Flomics_assembly_hub_links     = Channel.empty()
+    ch_Flomics_assembly_hub_trackDbs  = Channel.empty()
     FLOMICS_TRACKHUBS(bam_genome, bam_genome_indices)
-    ch_Flomics_trackhubs           = FLOMICS_TRACKHUBS.out.trackhubs_path.collect()
-    ch_Flomics_trackDbs            = FLOMICS_TRACKHUBS.out.trackDb_files.collect()
+    ch_Flomics_trackhubs              = FLOMICS_TRACKHUBS.out.trackhubs_path.collect()
+    ch_Flomics_trackDbs               = FLOMICS_TRACKHUBS.out.trackDb_files.collect()
+    ch_Flomics_assembly_hub_links     = FLOMICS_TRACKHUBS.out.assembly_hub_links.collect()
+    ch_Flomics_assembly_hub_trackDbs  = FLOMICS_TRACKHUBS.out.assembly_hub_trackDb_files.collect()
 
     ///
     /// Calculate the percentage of spliced reads and the percentage of splice junctions
@@ -97,7 +101,7 @@ workflow FLOMICS_QC{
     /// Aggregate all the QC from multiQC and extra QC into a new tsv
     ///
     ch_Flomics_QC_report            = Channel.empty()
-    FLOMICS_QC_AGGREGATOR ( samplesheet, multiqc_data, ch_Flomics_trackhubs, ch_Flomics_trackDbs, ch_Flomics_splicedReads_QC, ch_Flomics_spliceJunctions_QC,
+    FLOMICS_QC_AGGREGATOR ( samplesheet, multiqc_data, ch_Flomics_trackhubs, ch_Flomics_trackDbs, ch_Flomics_assembly_hub_links, ch_Flomics_assembly_hub_trackDbs, ch_Flomics_splicedReads_QC, ch_Flomics_spliceJunctions_QC,
     ch_Flomics_insert_size_QC, umi_dedup_rate_data, ch_Flomics_library_balance, ch_Flomics_FastQC, ch_Flomics_correlation_coefficients)
     ch_Flomics_QC_report            = FLOMICS_QC_AGGREGATOR.out.flomics_report
 

--- a/subworkflows/local/Flomics_QC.nf
+++ b/subworkflows/local/Flomics_QC.nf
@@ -36,13 +36,13 @@ workflow FLOMICS_QC{
     ///
     /// Makes the trackhubs and copies the bam files to the public bucket of s3
     ///
-    ch_Flomics_trackhubs              = Channel.empty()
-    ch_Flomics_trackDbs               = Channel.empty()
+    ch_Flomics_trackhub_links         = Channel.empty()
+    ch_Flomics_trackhub_trackDb_files = Channel.empty()
     ch_Flomics_assembly_hub_links     = Channel.empty()
     ch_Flomics_assembly_hub_trackDbs  = Channel.empty()
     FLOMICS_TRACKHUBS(bam_genome, bam_genome_indices)
-    ch_Flomics_trackhubs              = FLOMICS_TRACKHUBS.out.trackhubs_path.collect()
-    ch_Flomics_trackDbs               = FLOMICS_TRACKHUBS.out.trackDb_files.collect()
+    ch_Flomics_trackhub_links         = FLOMICS_TRACKHUBS.out.trackhub_links.collect()
+    ch_Flomics_trackhub_trackDb_files = FLOMICS_TRACKHUBS.out.trackhub_trackDb_files.collect()
     ch_Flomics_assembly_hub_links     = FLOMICS_TRACKHUBS.out.assembly_hub_links.collect()
     ch_Flomics_assembly_hub_trackDbs  = FLOMICS_TRACKHUBS.out.assembly_hub_trackDb_files.collect()
 
@@ -101,7 +101,7 @@ workflow FLOMICS_QC{
     /// Aggregate all the QC from multiQC and extra QC into a new tsv
     ///
     ch_Flomics_QC_report            = Channel.empty()
-    FLOMICS_QC_AGGREGATOR ( samplesheet, multiqc_data, ch_Flomics_trackhubs, ch_Flomics_trackDbs, ch_Flomics_assembly_hub_links, ch_Flomics_assembly_hub_trackDbs, ch_Flomics_splicedReads_QC, ch_Flomics_spliceJunctions_QC,
+    FLOMICS_QC_AGGREGATOR ( samplesheet, multiqc_data, ch_Flomics_trackhub_links, ch_Flomics_trackhub_trackDb_files, ch_Flomics_assembly_hub_links, ch_Flomics_assembly_hub_trackDbs, ch_Flomics_splicedReads_QC, ch_Flomics_spliceJunctions_QC,
     ch_Flomics_insert_size_QC, umi_dedup_rate_data, ch_Flomics_library_balance, ch_Flomics_FastQC, ch_Flomics_correlation_coefficients)
     ch_Flomics_QC_report            = FLOMICS_QC_AGGREGATOR.out.flomics_report
 


### PR DESCRIPTION
Assembly hubs are made to host custom genomes. This is needed in order to visualize read coverage on synthetic spike-in sequences, as those are not included in the native UCSC browser. See [FL-RNApipes - EPIC #2 - Set up UCSC assembly hub](https://app.asana.com/0/1203442788634762/1204250863361130).

This PR implements the creation of assembly hub based on the hg38 human genome + SIRV Set 3 spike-ins (IsoMix spike-ins + ERCC spike-ins) sequences. It mirrors the track hub creation process, extending the same processes and scripts.

Main files modified:

- make_trackDB.sh
- merge_trackDB.sh

Changes in the output:

- Trackhub files have been moved to its own subdirectory `trackhub/` on the flomics-public bucket.

Also implement a workaround for #54 .

Pipeline tested on 3 small fastq files from FL-EXP-0106.

Created new documentation on Slite: [Track hubs and assembly hubs](https://flomics.slite.com/app/docs/3JEkzI29WJ3VOu)

See development notes in bioinformatics notebook: [Assembly hub ERCC spike-ins](https://flomics.slite.com/app/docs/AHowKu0bfcQt59)