### PR TITLE
created empty channel so kraken2 can be skipped

### DIFF
--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -287,6 +287,7 @@ workflow RNASEQ {
     //
     // MODULE: Optional phylogenetic classification step
     //
+    ch_kraken2_multiqc = Channel.empty()
     if (params.phylo) {
         FLOMICS_PHYLO (ch_filtered_reads)
         ch_kraken2_multiqc = FLOMICS_PHYLO.out.kraken2_report


### PR DESCRIPTION
I realized that when setting the param `phylo` as `false` (very useful when testing the pipeline and wanting to skip the whole kraken2 subworkflow) an error is raised since MultiQC expects a channel that does not exist. I have set the creation of the channel as an empty channel before the `phylo` param is evaluated, that way the channel exists whether the pipeline runs the phylogenetic assignment or not. If the subworkflow is not executed, the channel is empty and this gets handled correctly downstream.

I have not tested it so I'm creating the pull request now but I'll upadate it when I have checked it works