### PR TITLE
if custom config exists, two config files are passed

### DIFF
--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -55,7 +55,7 @@ process MULTIQC {
 
     script:
     def args = task.ext.args ?: ''
-    def custom_config = params.multiqc_config ? "--config $multiqc_custom_config" : ''
+    def custom_config = params.multiqc_config ? "--config $multiqc_custom_config $multiqc_config" : "--config $multiqc_config"
     """
     multiqc \\
         -f \\

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -55,17 +55,33 @@ process MULTIQC {
 
     script:
     def args = task.ext.args ?: ''
-    def custom_config = params.multiqc_config ? "--config $multiqc_custom_config --config $multiqc_config" : "--config $multiqc_config"
-    """
-    multiqc \\
-        -f \\
-        $args \\
-        $custom_config \\
-        .
+    //def custom_config = params.multiqc_config ? "--config $multiqc_custom_config --config $multiqc_config" : "--config $multiqc_config"
+    if (params.multiqc_config) {
+        """
+        #Append user token to multiqc_config
+        cat $multiqc_custom_config >> $multiqc_config
+        multiqc \\
+            -f \\
+            $args \\
+            .
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
-    END_VERSIONS
-    """
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
+        END_VERSIONS
+        """
+    } else {
+        """
+        multiqc \\
+            -f \\
+            $args \\
+            .
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            multiqc: \$( multiqc --version | sed -e "s/multiqc, version //g" )
+        END_VERSIONS
+        """
+    }
+
 }

--- a/modules/local/multiqc.nf
+++ b/modules/local/multiqc.nf
@@ -55,7 +55,7 @@ process MULTIQC {
 
     script:
     def args = task.ext.args ?: ''
-    def custom_config = params.multiqc_config ? "--config $multiqc_custom_config $multiqc_config" : "--config $multiqc_config"
+    def custom_config = params.multiqc_config ? "--config $multiqc_custom_config --config $multiqc_config" : "--config $multiqc_config"
     """
     multiqc \\
         -f \\


### PR DESCRIPTION
As per [multiqc documentation](https://multiqc.info/docs/getting_started/config/), we can pass as many config files using the `--config` command, just like Nextflow does. so there is no need to join them or concatenate them.

So if the custom config with the megaqc credentials is passed to the pipeline with `--multiqc_config user_multiqc_config.yaml` multiqc will run like this:
```
multiqc \\
        -f \\
        --config user_multiqc_config.yaml multiqc_config.yaml(the one in the assets directory of the pipeline) \\
        .
```