### PR TITLE
removed links from the QC table, left the generation of links for the LIMS

### DIFF
--- a/modules/local/Flomics_QC_agreggator.nf
+++ b/modules/local/Flomics_QC_agreggator.nf
@@ -135,8 +135,7 @@ process FLOMICS_QC_AGGREGATOR{
     awk '{print $1"\t"$2"\t"$3"\t"$4}' correlation_coefs.tsv | head -n 1 > new_corr.tsv
     awk '{print $1"\t"$2"\t"$3"\t"$4}' correlation_coefs.tsv | tail -n+2 | sort -k1,1 >> new_corr.tsv
 
-    join -t $'\t' -j 1  samplenames.tsv  trackhub/trackhub_links.tsv | \\
-    join -t $'\t' -j 1 -  fastqc_QC.tsv | \\
+    join -t $'\t' -j 1  samplenames.tsv  fastqc_QC.tsv | \\
     join -t $'\t' -j 1 -  cutadapt_QC.tsv  | \\
     join -t $'\t' -j 1 -  STAR_QC.tsv  | \\
     join -t $'\t' -j 1 -  UMI_dedup_grouped.tsv  | \\


### PR DESCRIPTION
This small PR only removes the links from the QC table. The aggregator process is the one that uploads the trakchub files to S3 and also (I think) passes the links to the LIMS, so the part that does that has been left as it was.

There is another issue related to turning the generation of trackhubs ON/OFF, but is not the scope of this PR