### PR TITLE
`Number_mapped_unique_molecules` is now calculated on the genome BAM

### DIFF
--- a/workflows/rnaseq.nf
+++ b/workflows/rnaseq.nf
@@ -834,7 +834,7 @@ workflow RNASEQ {
     ch_Flomics_UMI_dedup_rate_QC = Channel.empty()
 
     if (params.with_umi) {
-        ch_bams_umi_dedup= DEDUP_UMI_UMITOOLS_TRANSCRIPTOME.out.bam.join(ALIGN_STAR.out.bam_transcript)
+        ch_bams_umi_dedup = DEDUP_UMI_UMITOOLS_GENOME.out.bam.join(ALIGN_STAR.out.bam)
 
         FLOMICS_UMI_DEDUP_QC (
             ch_bams_umi_dedup


### PR DESCRIPTION
On the QC table, we have two metrics related to the number of unique mapped molecules (the number and the percentage). Those statistics were calculated on the transcriptome BAM, but should be calculated on the genome BAM. This fix should solve the issue.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206777252434507